### PR TITLE
Fetching metadata from large sized flash chips

### DIFF
--- a/cyflash/bootload.py
+++ b/cyflash/bootload.py
@@ -86,6 +86,8 @@ def make_session(args, checksum_type):
 	if args.serial:
 		import serial
 		ser = serial.Serial(args.serial, args.serial_baudrate, timeout=args.timeout)
+		ser.flushInput()		# need to clear any garbage off the serial port
+		ser.flushOutput()
 		transport = protocol.SerialTransport(ser)
 	else:
 		raise BootloaderError("No valid interface specified")


### PR DESCRIPTION
The metadata is stored at the very top of the flash.  Fetch it from the _last_ row of the _last_ flash array.
