### PR TITLE
Make firmware image file error message more verbose

### DIFF
--- a/cyflash/cyacd.py
+++ b/cyflash/cyacd.py
@@ -44,7 +44,7 @@ class BootloaderData(object):
     def read(cls, f):
         header = f.readline().strip().decode('hex')
         if len(header) != 6:
-            raise ValueError("Expected 12 byte header line first")
+            raise ValueError("Expected 12 byte header line first, firmware file may be corrupt.")
         self = cls()
         self.silicon_id, self.silicon_rev, self.checksum_type = struct.unpack('>LBB', header)
         for i, line in enumerate(f):


### PR DESCRIPTION
Change error message from "Expected 12 byte header line first" to
"Expected 12 byte header line first, firmware file may be corrupt."
in order to make it clear the error is in the firmware image file,
not in the protocol with the device.

----
I hit this error message, and found the message in the forums indicating that this could
be due to a bad image file.  (I had in fact saved the html page.)  I think it would be helpful
to make the error message more explicit, identifying the firmware image file as the problem.