### PR TITLE
Added PSOC 4 to CANbus_Bootloader.c. Removed arbitration id filtering with hardcoded filter in protocol.py.

### DIFF
--- a/PSOC/CANbus_Bootloader.c
+++ b/PSOC/CANbus_Bootloader.c
@@ -52,7 +52,7 @@
 //  #define CAN_TX_MAILBOX_IS_FULL(i) (CAN_BUF_SR_REG.byte[2] & (uint8)(1u << i))
 #   define CAN_TX_MAILBOX_IS_FULL(i) (CAN_TX[i].txcmd.byte[0] & CAN_TX_REQUEST_PENDING)
 #else  /* CY_PSOC4 */
-#   error CAN_TX_MAILBOX_IS_FULL is only implemented on PSOC3/PSOC5
+#   define CAN_TX_MAILBOX_IS_FULL(i) ((CAN_TX_CMD_REG(i) & CAN_TX_REQUEST_PENDING) != 0)
 #endif /* CY_PSOC3 || CY_PSOC5 */
 
 // --------------------------------------------------------------------------

--- a/cyflash/protocol.py
+++ b/cyflash/protocol.py
@@ -476,9 +476,8 @@ class CANbusTransport(object):
             if (not frame):
                 raise BootloaderTimeoutError("Timed out waiting for Bootloader 1st response frame")
 
-            if frame.arbitration_id & 0x700 != 0x700:
-                print("Invalid frame, discarding", frame)
-                continue;
+            if frame.arbitration_id != self.frame_id:
+                continue
 
             # Don't check the frame arbitration ID, it may be used for varying purposes
 
@@ -498,11 +497,6 @@ class CANbusTransport(object):
             frame = self.transport.recv(self.timeout)
             if (not frame):
                 raise BootloaderTimeoutError("Timed out waiting for Bootloader response frame")
-
-            if frame.arbitration_id & 0x700 != 0x700:
-                print("Invalid frame 2, discarding", frame)
-                #got a frame from another device, ignore
-                continue
 
             if (self.echo_frames) and (frame.arbitration_id != self.frame_id):
                 # Got a frame from another device, ignore


### PR DESCRIPTION
1. I'm developing on PSOC 4 and managed to get CANbus_Bootloader.c work for these devices (see below the line change). Before the compiler was throwing an error saying that it was implemented only for PSOC3/PSOC5.

2. I removed the arbitration id filtering with the hardcoded filter 0x700.
Maybe filtering should be implemented with python-can set_filter command, which accepts a mask as an argument (not done yet but I could look into it).